### PR TITLE
Remove the 5-page limit: allow infinite number of pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.greenwoodmc</groupId>
     <artifactId>HelpCommand</artifactId>
-    <version>2.6.3</version>
+    <version>2.7.0</version>
     <packaging>jar</packaging>
 
     <name>HelpCommand</name>

--- a/src/main/java/net/greenwoodmc/helpcommand/commands/help.java
+++ b/src/main/java/net/greenwoodmc/helpcommand/commands/help.java
@@ -25,103 +25,53 @@ public class help implements CommandExecutor {
         } else {
             Player player = (Player) sender;
             String ver;
-            String arg1;
+            Integer currPageNumber;
+            Integer nextPageNumber;
             String colour1 = config.getString("pagePrompt.mainTextColour");
             String colour2 = config.getString("pagePrompt.pageNumberColour");
             ChatColor COLOUR1 = ChatColor.valueOf(colour1);
             ChatColor COLOUR2 = ChatColor.valueOf(colour2);
             String nextPage = config.getString("pagePrompt.mainText");
             List<Integer> enabledPages = config.getIntegerList("pagesEnabled");
+            Integer lastPage = config.getInt("numberOfPages");
             JavaPlugin plug = JavaPlugin.getPlugin(HelpCommand.class);
 
             if (cmd.getName().equalsIgnoreCase("help")) {
                 if (config.getBoolean("helpcmd")) {
                     if (args.length >= 1) {
-                        arg1 = args[0];
                         // For if there's 2 args
-                        if (arg1.equals("1")) {
-                            // arg = 1
-                            if (enabledPages.contains(1)) {
-                                ver = (String) config.getStringList("help.1").stream().collect(Collectors.joining("\n"));
+                        currPageNumber = Integer.valueOf(args[0]);
+                        nextPageNumber = currPageNumber + 1;
+                        if (currPageNumber > 0 && currPageNumber < lastPage) {
+                            // If between 1 and the last page number - 1
+                            if (enabledPages.contains(currPageNumber)) {
+                                ver = (String) config.getStringList("help." + currPageNumber).stream().collect(Collectors.joining("\n"));
                                 player.sendMessage(TextUtil.color(ver));
-                                if (enabledPages.contains(2)) {
+                                if (enabledPages.contains(nextPageNumber)) {
                                     ComponentBuilder nextPageMSG = new ComponentBuilder(nextPage)
                                             .color(COLOUR1)
-                                            .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/help 2"))
-                                            .append("2")
+                                            .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/help " + nextPageNumber))
+                                            .append(String.valueOf(nextPageNumber))
                                             .color(COLOUR2);
                                     player.spigot().sendMessage(nextPageMSG.create());
                                 }
                             } else {
                                 player.sendMessage(TextUtil.color(config.getString("pageNA")));
                             }
-                        }
-                        if (arg1.equals("2")) {
-                            // arg = 2
-                            if (enabledPages.contains(2)) {
-                                ver = (String) config.getStringList("help.2").stream().collect(Collectors.joining("\n"));
-                                player.sendMessage(TextUtil.color(ver));
-                                if (enabledPages.contains(3)) {
-                                    ComponentBuilder nextPageMSG = new ComponentBuilder(nextPage)
-                                            .color(COLOUR1)
-                                            .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/help 3"))
-                                            .append("3")
-                                            .color(COLOUR2);
-                                    player.spigot().sendMessage(nextPageMSG.create());
-                                }
-                            } else {
-                                player.sendMessage(TextUtil.color(config.getString("pageNA")));
-                            }
-                        }
-                        if (arg1.equals("3")) {
-                            // arg = 3
-                            if (enabledPages.contains(3)) {
-                                ver = (String) config.getStringList("help.3").stream().collect(Collectors.joining("\n"));
-                                player.sendMessage(TextUtil.color(ver));
-                                if (enabledPages.contains(4)) {
-                                    ComponentBuilder nextPageMSG = new ComponentBuilder(nextPage)
-                                            .color(COLOUR1)
-                                            .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/help 4"))
-                                            .append("4")
-                                            .color(COLOUR2);
-                                    player.spigot().sendMessage(nextPageMSG.create());
-                                }
-                            } else {
-                                player.sendMessage(TextUtil.color(config.getString("pageNA")));
-                            }
-                        }
-                        if (arg1.equals("4")) {
-                            // arg = 4
-                            if (enabledPages.contains(4)) {
-                                ver = (String) config.getStringList("help.4").stream().collect(Collectors.joining("\n"));
-                                player.sendMessage(TextUtil.color(ver));
-                                if (enabledPages.contains(5)) {
-                                    ComponentBuilder nextPageMSG = new ComponentBuilder(nextPage)
-                                            .color(COLOUR1)
-                                            .event(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/help 5"))
-                                            .append("5")
-                                            .color(COLOUR2);
-                                    player.spigot().sendMessage(nextPageMSG.create());
-                                }
-                            } else {
-                                player.sendMessage(TextUtil.color(config.getString("pageNA")));
-                            }
-                        }
-                        if (arg1.equals("5")) {
-                            // arg = 5
-                            if (enabledPages.contains(5)) {
-                                ver = (String) config.getStringList("help.5").stream().collect(Collectors.joining("\n"));
+                        } else if (currPageNumber.equals(lastPage)) {
+                            // If the last page number
+                            if (enabledPages.contains(lastPage)) {
+                                ver = (String) config.getStringList("help." + lastPage).stream().collect(Collectors.joining("\n"));
                                 player.sendMessage(TextUtil.color(ver));
                             } else {
                                 player.sendMessage(TextUtil.color(config.getString("pageNA")));
                             }
-                        }
-                        if (Integer.parseInt(arg1) > 5 || 1 > Integer.parseInt(arg1)) {
-                            // If larger than 5 or smaller than 1
+                        } else if (currPageNumber < 1 || currPageNumber > lastPage) {
+                            // If smaller than 1 or larger than the last page number
                             player.sendMessage(TextUtil.color(config.getString("pageNA")));
                         }
                     } else {
-                        // Page 1
+                        // If no page number specified, send page 1
                         if (enabledPages.contains(2)) {
                             // If page 2 exists
                             ver = (String) config.getStringList("help.1").stream().collect(Collectors.joining("\n"));
@@ -139,8 +89,8 @@ public class help implements CommandExecutor {
                         }
                     }
                 } else {
-                    arg1 = config.getString("disabled");
-                    player.sendMessage(TextUtil.color(arg1));
+                    currPageNumber = Integer.valueOf(config.getString("disabled"));
+                    player.sendMessage(TextUtil.color(String.valueOf(currPageNumber)));
                 }
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -66,10 +66,21 @@ help:
     - "&b/ban &7&l- &r&dBan a player"
     - "&b/tpahere &7&l- &r&dRequest to teleport a player to you"
     - "&5----------"
+  6:
+    - "&5----------"
+    - "&b&lServer&d&lName"
+    - "&bPage 6"
+    - "&5----------"
+    - "&b/fly &7&l- &r&dToggle flying mode"
+    - "&b/nick &7&l- &r&dChange your nickname"
+    - "&b/mail &7&l- &r&dSend a mail to a player"
+    - "&b/beezooka &7&l- &r&dShoot a fake bee in the air"
+    - "&5----------"
 
 # It is recommended not to delete these pages and to just use the pagesEnabled list to control which pages are to be available
 
-pagesEnabled: [1,2,3,4,5] # sets the pages that can be accessed (max 5)
+pagesEnabled: [1,2,3,4,5,6] # sets the pages that can be accessed
+numberOfPages: 6
 ######################################
 # Enabled Commands
 ######################################

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HelpCommand
-version: '2.6.3-PublicRelease'
+version: '2.7.0-PublicRelease'
 main: net.greenwoodmc.helpcommand.HelpCommand
 api-version: 1.18
 authors: [ VoidemLIVE ]


### PR DESCRIPTION
I forked your plugin to remove the 5-page limit: here's the changes for that :)
We remove all the hard-coded stuff for pages 1-5: instead of checking each page manually, we check whether it's a page in the range of existing pages, the last page, or a page outside the range. There's a new line in the config for how many pages there are - we find out the last page via this. Variables currPageNumber & nextPageNumber replace the hard-coded values for page numbers.

I also replaced the separate if statements with else-ifs, and added a 6th page to the config to help test it works.